### PR TITLE
Renamed ordering method from 'then' to 'subsequently' to avoid promise conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ expect(spy.getCall(2).args[0]).to.equal(3);
 Using `sinon-chai-in-order`, you can say this instead:
 
 ```javascript
-expect(spy).inOrder.to.have.been.calledWith(1).then.calledWith(2).then.calledWith(3);
+expect(spy).inOrder.to.have.been.calledWith(1)
+                   .subsequently.calledWith(2)
+                   .subsequently.calledWith(3);
 ```
 
 ## Setup
@@ -41,12 +43,6 @@ chai.use(sinonChaiInOrder);
 This plugin is distributed in [UMD](https://github.com/umdjs/umd) format so you can use it everywhere. However, it is exported as an ES6 module. If using ES5, please use:
 ```javascript
 chai.use(require('chai-react-element').default);
-```
-
-### Interoperability
-This module conflicts with [Chai As Promised](https://github.com/domenic/chai-as-promised), where both modules attempt to add a `then` method to `chai.Assertion`. To work around it, override `chaiAsPromised.transferPromiseness` as follows:
-```js
-chaiAsPromised.transferPromiseness = function(a, b) {};
 ```
 
 ## Contributing

--- a/src/sinon-chai-in-order.js
+++ b/src/sinon-chai-in-order.js
@@ -10,7 +10,7 @@ export default function sinonChaiInOrder(chai, utils) {
         }
     });
 
-    chai.Assertion.overwriteProperty('then', function (_super) {
+    chai.Assertion.overwriteProperty('subsequently', function (_super) {
         return function() {
             const context = utils.flag(this, 'inOrderContext');
             if (context) {

--- a/test/sinon-chai-in-order.spec.js
+++ b/test/sinon-chai-in-order.spec.js
@@ -12,8 +12,21 @@ describe('.inOrder', function() {
         [1, 2, 3].forEach(spy);
 
         expect(() => {
-            expect(spy).inOrder.to.have.been.calledWith(1).then.calledWith(2).then.calledWith(3);
+            expect(spy).inOrder.to.have.been.calledWith(1)
+                               .subsequently.calledWith(2)
+                               .subsequently.calledWith(3);
         }).not.to.throw();
+    });
+
+    it('fails when assertion order is incorrect', function() {
+        const spy = sinon.spy();
+        [1, 2, 3].forEach(spy);
+
+        expect(() => {
+            expect(spy).inOrder.to.have.been.calledWith(1)
+                               .subsequently.calledWith(3)
+                               .subsequently.calledWith(2);
+        }).to.throw('expected spy to have been called with arguments 3');
     });
 
     it('fails when asserted object is not a spy', function() {
@@ -24,10 +37,12 @@ describe('.inOrder', function() {
     });
 });
 
-describe('.then', function() {
+describe('.subsequently', function() {
     it('does nothing if asserted object is not a spy call', function() {
         const obj = "obj";
-        expect(expect(obj).then).to.have.property("_obj").that.equals(obj);
+        expect(expect(obj).subsequently)
+          .to.have.property("_obj")
+          .that.equals(obj);
     });
 
     it('fails if no spy call was found', function() {
@@ -35,7 +50,8 @@ describe('.then', function() {
         spy(1);
 
         expect(() => {
-            expect(spy).inOrder.to.have.been.calledWith(1).then.calledWith(2);
+            expect(spy).inOrder.to.have.been.calledWith(1)
+                               .subsequently.calledWith(2);
         }).to.throw("spy was only called 1 time(s)");
     });
 });


### PR DESCRIPTION
Subsequently is more verbose than 'then' but I think that the spacing really works cleanly in conjunction with to.have.been and will make sure that there is less of a conflict possibility.  Also makes it easier to search for use instances since when do you ever see the word subsequently used by a library/code
